### PR TITLE
Minor changes to the tensor classes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Added `copy` for the core tensor structures
 
 
 ### Changed
 
+- For all tensor representation all their data values can (should) only be accessed through corresponding properties.
+- Objects of `Tensor` class can only be created from numpy arrays
 
 
 ### Removed


### PR DESCRIPTION
1. Added `copy` for the core tensor structures
2. Objects of `Tensor` class can only be created from numpy arrays
3. For all tensor representation all their data values can (should) only be accessed through corresponding properties.
4. Minor changes to docstirings of tensor structures