### PR TITLE
Interactive dashboard Kruskal and Tucker representaitons.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 test_[0-9]*
 Untitled*.ipynb
 .coveragerc-dev
+.reports/
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [HOTTBOX v0.1.4 Unreleased]
 
 ### Package status on branch develop
-[![Travis status](https://img.shields.io/travis/hottbox/hottbox/develop.svg?label=TravisCI)](https://travis-ci.org/hottbox/hottbox/)
+[![Travis status](https://travis-ci.org/hottbox/hottbox.svg?branch=develop)](https://travis-ci.org/hottbox/hottbox/)
 [![Appveyor status](https://ci.appveyor.com/api/projects/status/2ct6ku31v351s3d3/branch/develop?svg=true)](https://ci.appveyor.com/project/IlyaKisil/hottbox-6jq6a/branch/develop)
-[![Coveralls status](https://img.shields.io/coveralls/github/hottbox/hottbox/develop.svg)](https://coveralls.io/github/hottbox/hottbox)
+[![Coveralls status](https://coveralls.io/repos/github/hottbox/hottbox/badge.svg?branch=develop)](https://coveralls.io/github/hottbox/hottbox?branch=develop)
 
 ### Added
 - [ ] Canonical mode-n unfolding

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+
+test:
+	pytest -v hottbox
+
+test-cov:
+	pytest -v --cov hottbox --cov-branch --cov-report term-missing
+
+install:
+	pip install -e .
+
+code-check:
+	bandit -r hottbox -c bandit.yml -f html -o .reports/hottbox-bandit.html
+
+check-all: test-cov code-check

--- a/README.rst
+++ b/README.rst
@@ -1,22 +1,27 @@
 HOTTBOX: Higher Order Tensors ToolBOX
 =====================================
 
-|Travis|_ |Appveyor|_ |Coveralls|_ |PyPi|_
+|Travis|_ |Appveyor|_ |Coveralls|_ |PyPi|_ |Binder|_
 
-.. |Travis| image:: https://img.shields.io/travis/hottbox/hottbox/master.svg?label=TravisCI
+.. |Travis| image:: https://travis-ci.org/hottbox/hottbox.svg?branch=master
 .. _Travis: https://travis-ci.org/hottbox/hottbox/
 
-.. |Appveyor| image:: https://ci.appveyor.com/api/projects/status/2ct6ku31v351s3d3/branch/master?svg=true
+.. |Appveyor| image:: https://ci.appveyor.com/api/projects/status/sh2rk41gpn26h7a7/branch/master?svg=true
 .. _Appveyor: https://ci.appveyor.com/project/IlyaKisil/hottbox-6jq6a
 
-.. |Coveralls| image:: https://img.shields.io/coveralls/github/hottbox/hottbox/master.svg
-.. _Coveralls: https://coveralls.io/github/hottbox/hottbox
+.. |Coveralls| image:: https://coveralls.io/repos/github/hottbox/hottbox/badge.svg?branch=master
+.. _Coveralls: https://coveralls.io/github/hottbox/hottbox?branch=master
 
 .. |PyPi| image:: https://badge.fury.io/py/hottbox.svg
 .. _PyPi: https://badge.fury.io/py/hottbox
 
-Welcome to the toolbox for tensor decompositions, statistical analysis, visualisation, feature extraction, 
-regression and non-linear classification of multi-dimensional data. 
+.. |Binder| image:: https://mybinder.org/badge.svg
+.. _Binder: https://mybinder.org/v2/gh/hottbox/hottbox-tutorials/master
+
+Welcome to the toolbox for tensor decompositions, statistical analysis, visualisation, feature extraction,
+regression and non-linear classification of multi-dimensional data. Not sure you need this toolbox? Give it
+a try on `mybinder.org <https://mybinder.org/v2/gh/hottbox/hottbox-tutorials/master>`_ without installation.
+
 
 
 Installing HOTTBOX

--- a/bandit.yml
+++ b/bandit.yml
@@ -1,0 +1,2 @@
+# do not check assert statements
+skips: ['B101']

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,22 +1,26 @@
 HOTTBOX: Higher Order Tensors ToolBOX
 =====================================
 
-|Travis|_ |Appveyor|_ |Coveralls|_ |PyPi|_
+|Travis|_ |Appveyor|_ |Coveralls|_ |PyPi|_ |Binder|_
 
-.. |Travis| image:: https://img.shields.io/travis/hottbox/hottbox/master.svg?label=TravisCI
+.. |Travis| image:: https://travis-ci.org/hottbox/hottbox.svg?branch=master
 .. _Travis: https://travis-ci.org/hottbox/hottbox/
 
 .. |Appveyor| image:: https://ci.appveyor.com/api/projects/status/sh2rk41gpn26h7a7/branch/master?svg=true
 .. _Appveyor: https://ci.appveyor.com/project/IlyaKisil/hottbox-6jq6a
 
-.. |Coveralls| image:: https://img.shields.io/coveralls/github/hottbox/hottbox/master.svg
-.. _Coveralls: https://coveralls.io/github/hottbox/hottbox
+.. |Coveralls| image:: https://coveralls.io/repos/github/hottbox/hottbox/badge.svg?branch=master
+.. _Coveralls: https://coveralls.io/github/hottbox/hottbox?branch=master
 
 .. |PyPi| image:: https://badge.fury.io/py/hottbox.svg
 .. _PyPi: https://badge.fury.io/py/hottbox
 
+.. |Binder| image:: https://mybinder.org/badge.svg
+.. _Binder: https://mybinder.org/v2/gh/hottbox/hottbox-tutorials/master
+
 Welcome to the toolbox for tensor decompositions, statistical analysis, visualisation, feature extraction,
-regression and non-linear classification of multi-dimensional data.
+regression and non-linear classification of multi-dimensional data. Not sure you need this toolbox? Give it
+a try on `mybinder.org <https://mybinder.org/v2/gh/hottbox/hottbox-tutorials/master>`_ without installation.
 
 .. toctree::
    :maxdepth: 2

--- a/docs/source/tutorials.rst
+++ b/docs/source/tutorials.rst
@@ -1,9 +1,42 @@
 HOTTBOX Tutorials
 =================
 
+.. |ti1| image:: https://mybinder.org/badge.svg
+.. _ti1: https://mybinder.org/v2/gh/hottbox/hottbox-tutorials/master?filepath=1_N-dimensional_arrays_and_Tensor_class.ipynb
+.. _Tutorial1: https://github.com/hottbox/hottbox-tutorials/blob/master/1_N-dimensional_arrays_and_Tensor_class.ipynb
+
+.. |ti2| image:: https://mybinder.org/badge.svg
+.. _ti2: https://mybinder.org/v2/gh/hottbox/hottbox-tutorials/master?filepath=2_Efficient_representations_of_tensors.ipynb
+.. _Tutorial2: https://github.com/hottbox/hottbox-tutorials/blob/master/2_Efficient_representations_of_tensors.ipynb
+
+
+.. |ti3| image:: https://mybinder.org/badge.svg
+.. _ti3: https://mybinder.org/v2/gh/hottbox/hottbox-tutorials/master?filepath=3_Fundamental_tensor_decompositions.ipynb
+.. _Tutorial3: https://github.com/hottbox/hottbox-tutorials/blob/master/3_Fundamental_tensor_decompositions.ipynb
+
+.. |ti4| image:: https://mybinder.org/badge.svg
+.. _ti4: https://mybinder.org/v2/gh/hottbox/hottbox-tutorials/master?filepath=4_Ecosystem_of_Tensor_class.ipynb
+.. _Tutorial4: https://github.com/hottbox/hottbox-tutorials/blob/master/4_Ecosystem_of_Tensor_class.ipynb
+
+
+.. |ti5| image:: https://mybinder.org/badge.svg
+.. _ti5: https://mybinder.org/v2/gh/hottbox/hottbox-tutorials/master?filepath=5_Tensor_meta_information_and_pandas_integration.ipynb
+.. _Tutorial5: https://github.com/hottbox/hottbox-tutorials/blob/master/5_Tensor_meta_information_and_pandas_integration.ipynb
+
 Please check out `our repository <https://github.com/hottbox/hottbox-tutorials>`_ with tutorials on ``hottbox`` api
 and theoretical background on multi-linear algebra and tensor decompositions:
 
 1. `Tensor class for N-dimensional arrays and its functionality <https://github.com/hottbox/hottbox-tutorials/blob/master/1_N-dimensional_arrays_and_Tensor_class.ipynb>`_.
+    |ti1|_
 2. `Efficient representation of N-dimensional arrays: TensorCPD, TensorTKD, TensorTT <https://github.com/hottbox/hottbox-tutorials/blob/master/2_Efficient_representations_of_tensors.ipynb>`_.
+    |ti2|_
 3. `Fundamental tensor decompositions <https://github.com/hottbox/hottbox-tutorials/blob/master/3_Fundamental_tensor_decompositions.ipynb>`_.
+    |ti3|_
+4. `Ecosystem of Tensor class and transformations <https://github.com/hottbox/hottbox-tutorials/blob/master/4_Ecosystem_of_Tensor_class.ipynb>`_
+    |ti4|_
+5. `Tensor meta information and pandas integration <https://github.com/hottbox/hottbox-tutorials/blob/master/5_Tensor_meta_information_and_pandas_integration.ipynb>`_
+    |ti5|_
+
+
+
+

--- a/hottbox/algorithms/decomposition/base.py
+++ b/hottbox/algorithms/decomposition/base.py
@@ -123,7 +123,7 @@ def _pprint(params, offset=0, printer=repr):
     line_sep = ',\n' + (1 + offset // 2) * ' '
     for i, name in enumerate(param_names):
         value = params[name]
-        if type(value) is float:
+        if isinstance(value, float):
             this_repr = '%s=%s' % (name, str(value))
         else:
             this_repr = '%s=%s' % (name, printer(value))

--- a/hottbox/core/_meta.py
+++ b/hottbox/core/_meta.py
@@ -141,7 +141,7 @@ class State(object):
         return self.mode_order == self.normal_mode_order
 
     def change_normal_shape(self, normal_shape):
-        """ Change shape of a `Tensor` object in normal format dut to mode-n product or contraction
+        """ Change shape of a ``Tensor`` object in normal format due to mode-n product or contraction
 
         Parameters
         ----------

--- a/hottbox/core/tests/test_structures.py
+++ b/hottbox/core/tests/test_structures.py
@@ -6,6 +6,7 @@ from functools import reduce
 from ..structures import *
 from ..operations import unfold, kolda_unfold
 from .._meta import State
+from ...errors import TensorModeError, TensorShapeError, TensorStateError, TensorTopologyError, ModeError, StateError
 
 
 # TODO: find a better way to test the methods that only prints and for __repr__ and __str__
@@ -85,29 +86,29 @@ class TestTensor:
 
         # ------ tests for custom mode names being incorrectly defined
         # mode names are not of list type
-        with pytest.raises(TypeError):
+        with pytest.raises(ModeError):
             incorrect_mode_names = {mode: "{}-mode".format(mode) for mode in range(order)}
             Tensor(array=correct_data, mode_names=incorrect_mode_names)
 
         # not enough mode names
-        with pytest.raises(ValueError):
+        with pytest.raises(ModeError):
             incorrect_mode_names = ["{}-mode".format(mode) for mode in range(order - 1)]
             Tensor(array=correct_data, mode_names=incorrect_mode_names)
 
         # too many mode names
-        with pytest.raises(ValueError):
+        with pytest.raises(ModeError):
             incorrect_mode_names = ["{}-mode".format(mode) for mode in range(order + 1)]
             Tensor(array=correct_data, mode_names=incorrect_mode_names)
 
         # all mode names should be strings
-        with pytest.raises(TypeError):
+        with pytest.raises(ModeError):
             incorrect_mode_names = ["{}-mode".format(mode) for mode in range(order)]
             incorrect_mode_names[0] = 0
             Tensor(array=correct_data, mode_names=incorrect_mode_names)
 
         # ------ tests for custom state being incorrectly defined
         # custom state should be passed as a dict
-        with pytest.raises(TypeError):
+        with pytest.raises(StateError):
             I, J, K = 2, 4, 8
             correct_data = np.ones(I * J * K).reshape(I, J, K)
             correct_normal_shape = (I, J, K)
@@ -120,7 +121,7 @@ class TestTensor:
             Tensor(array=correct_data, custom_state=incorrect_custom_state)
 
         # custom state not fully defined
-        with pytest.raises(ValueError):
+        with pytest.raises(StateError):
             I, J, K = 2, 4, 8
             correct_data = np.ones(I * J * K).reshape(I, J, K)
             correct_normal_shape = (I, J, K)
@@ -132,7 +133,7 @@ class TestTensor:
             Tensor(array=correct_data, custom_state=incorrect_custom_state)
 
         # normal shape of custom state should be a tuple
-        with pytest.raises(TypeError):
+        with pytest.raises(StateError):
             I, J, K = 2, 4, 8
             correct_data = np.ones(I * J * K).reshape(I, J, K)
             incorrect_normal_shape = [I, J, K]
@@ -145,7 +146,7 @@ class TestTensor:
             Tensor(array=correct_data, custom_state=incorrect_custom_state)
 
         # normal shape of custom state is inconsistent with the shape of provided data
-        with pytest.raises(ValueError):
+        with pytest.raises(StateError):
             I, J, K = 2, 4, 8
             correct_data = np.ones(I * J * K).reshape(I, J, K)
             incorrect_normal_shape = (I+1, J, K)
@@ -158,7 +159,7 @@ class TestTensor:
             Tensor(array=correct_data, custom_state=incorrect_custom_state)
 
         # mode order of custom state should be a !! TUPLE !! of lists
-        with pytest.raises(TypeError):
+        with pytest.raises(StateError):
             I, J, K = 2, 4, 8
             correct_data = np.ones(I * J * K).reshape(I, J, K)
             correct_normal_shape = (I, J, K)
@@ -171,7 +172,7 @@ class TestTensor:
             Tensor(array=correct_data, custom_state=incorrect_custom_state)
 
         # mode order of custom state should be a tuple of !! LISTS !!
-        with pytest.raises(TypeError):
+        with pytest.raises(StateError):
             I, J, K = 2, 4, 8
             correct_data = np.ones(I * J * K).reshape(I, J, K)
             correct_normal_shape = (I, J, K)
@@ -184,7 +185,7 @@ class TestTensor:
             Tensor(array=correct_data, custom_state=incorrect_custom_state)
 
         # number of list in mode order should correspond to the number of dimensions of provided data
-        with pytest.raises(ValueError):
+        with pytest.raises(StateError):
             I, J, K = 2, 4, 8
             correct_data = np.ones(I * J * K).reshape(I, J, K)
             correct_normal_shape = (I, J, K)
@@ -195,7 +196,7 @@ class TestTensor:
                                           mode_order=incorrect_mode_order,
                                           rtype=correct_rtype)
             Tensor(array=correct_data, custom_state=incorrect_custom_state)
-        with pytest.raises(ValueError):
+        with pytest.raises(StateError):
             I, J, K = 2, 4, 8
             correct_data = np.ones(I * J * K).reshape(I, J*K)
             correct_normal_shape = (I, J, K)
@@ -208,7 +209,7 @@ class TestTensor:
             Tensor(array=correct_data, custom_state=incorrect_custom_state)
 
         # length of mode order of custom state is inconsistent with the normal shape
-        with pytest.raises(ValueError):
+        with pytest.raises(StateError):
             I, J, K = 2, 4, 8
             correct_data = np.ones(I * J * K).reshape(I, J, K)
             correct_normal_shape = (I, J, K)
@@ -221,7 +222,7 @@ class TestTensor:
             Tensor(array=correct_data, custom_state=incorrect_custom_state)
 
         # length of normal shape of custom state is inconsistent with the length of provided mode names
-        with pytest.raises(ValueError):
+        with pytest.raises(ModeError):
             I, J, K = 2, 4, 8
             correct_data = np.ones(I * J * K).reshape(I, J, K)
             correct_normal_shape = (I, J, K)
@@ -304,18 +305,18 @@ class TestTensor:
         with pytest.raises(TypeError):
             assert Tensor(data_1) + data_1
 
-        with pytest.raises(ValueError):
+        with pytest.raises(TensorStateError):
             tensor_1 = Tensor(array=data_1)
             tensor_2 = Tensor(array=data_2).unfold(mode=0, inplace=True)
             assert tensor_1 + tensor_2
 
-        with pytest.raises(ValueError):
+        with pytest.raises(TensorModeError):
             mode_index = {0: ["idx1", "idx2"]}
             tensor_1 = Tensor(array=data_1)
             tensor_2 = Tensor(array=data_2).set_mode_index(mode_index=mode_index)
             assert tensor_1 + tensor_2
 
-        with pytest.raises(ValueError):
+        with pytest.raises(TensorShapeError):
             data_2 = np.arange(2*2).reshape(2,2)
             tensor_1 = Tensor(array=data_1)
             tensor_2 = Tensor(array=data_2)
@@ -380,22 +381,22 @@ class TestTensor:
         assert tensor.mode_names == list(true_new_mode_names.values())
 
         # ------ tests that should FAIL for new mode names being incorrectly defined for renaming
-        with pytest.raises(ValueError):
+        with pytest.raises(ModeError):
             # too many mode names
             incorrect_new_mode_names = {mode: "{}-mode".format(mode) for mode in range(true_order + 1)}
             tensor.set_mode_names(mode_names=incorrect_new_mode_names)
 
-        with pytest.raises(TypeError):
+        with pytest.raises(ModeError):
             # incorrect type of keys (not integers)
             incorrect_new_mode_names = {"{}-mode".format(mode): mode for mode in range(true_order)}
             tensor.set_mode_names(mode_names=incorrect_new_mode_names)
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ModeError):
             # key value exceeds the order of a tensor
             incorrect_new_mode_names = {mode: "{}-mode".format(mode) for mode in range(true_order - 2, true_order + 1)}
             tensor.set_mode_names(mode_names=incorrect_new_mode_names)
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ModeError):
             # key value is set to be negative
             incorrect_new_mode_names = {mode: "{}-mode".format(mode) for mode in range(-1, true_order - 1)}
             tensor.set_mode_names(mode_names=incorrect_new_mode_names)
@@ -428,29 +429,29 @@ class TestTensor:
         tensor = Tensor(array=data)
 
         # ------ tests that should FAIL for new mode index being incorrectly defined for renaming
-        with pytest.raises(ValueError):
+        with pytest.raises(ModeError):
             # too many lists of indices provided
             mode_index = {i: ["index"] for i in range(len(shape)+1)}
             tensor.set_mode_index(mode_index=mode_index)
 
-        with pytest.raises(TypeError):
+        with pytest.raises(ModeError):
             # incorrect type of keys (not integers)
-            mode_index = {"index".format(mode): mode for mode in range(true_order)}
+            mode_index = {"index-name": mode for mode in range(true_order)}
             tensor.set_mode_index(mode_index=mode_index)
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ModeError):
             # key value exceeds the order of a tensor
             wrong_key = true_order + 1
             mode_index = {wrong_key : ["idx"]}
             tensor.set_mode_index(mode_index=mode_index)
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ModeError):
             # key value exceeds the order of a tensor
             wrong_key = -1
             mode_index = {wrong_key : ["idx"]}
             tensor.set_mode_index(mode_index=mode_index)
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ModeError):
             # not enough indices for the length of the mode
             mode_index = {0: ["idx"]}
             tensor.set_mode_index(mode_index=mode_index)
@@ -557,12 +558,12 @@ class TestTensor:
             Tensor(array=orig_data).unfold(mode=0, rtype="dummy", inplace=True)
 
         # Tests for checking normal state of a tensor
-        with pytest.raises(TypeError):
+        with pytest.raises(TensorStateError):
             # Should not unfold several times in a row
             Tensor(array=orig_data).unfold(mode=0, inplace=True).unfold(mode=0, inplace=True)
 
-        with pytest.raises(TypeError):
-            # Should not fold inf it wasn't unfolded before
+        with pytest.raises(TensorStateError):
+            # Should not fold if it wasn't unfolded before
             Tensor(array=orig_data).fold(inplace=True)
 
     def test_vectorise(self):
@@ -622,7 +623,7 @@ class TestTensor:
             Tensor(array=orig_data).vectorise(rtype="dummy", inplace=True)
 
         # Tests for checking normal state of a tensor
-        with pytest.raises(TypeError):
+        with pytest.raises(TensorStateError):
             # Should vectorise a tensor only if it was in normal state
             Tensor(array=orig_data).unfold(mode=0, inplace=True).vectorise(inplace=True)
 
@@ -670,7 +671,7 @@ class TestTensor:
             np.testing.assert_array_equal(tensor.data, array_3d)
 
         # check that mode_n_product can be performed only on a tensor in normal state
-        with pytest.raises(TypeError):
+        with pytest.raises(TensorStateError):
             tensor = Tensor(array=array_3d).unfold(mode=0, inplace=True)
             matrix = np.arange(2)
             tensor.mode_n_product(matrix, mode=0)
@@ -683,10 +684,10 @@ class TestTensor:
         orig_names = ['country', 'model', 'year']
 
         # check that names have not been changed when multiply with numpy array
-        for mode in range(len(new_dim)):
+        for i, mode in enumerate(new_dim):
             tensor = Tensor(array=array_3d, mode_names=orig_names)
-            matrix = np.arange(new_dim[mode] * orig_dim[mode]).reshape(new_dim[mode], orig_dim[mode])
-            tensor.mode_n_product(matrix, mode=mode)
+            matrix = np.arange(mode * orig_dim[i]).reshape(mode, orig_dim[i])
+            tensor.mode_n_product(matrix, mode=i)
             assert (tensor.mode_names == orig_names)
 
         # check that names have not been changed when multiply with matrix as a Tensor object with default names
@@ -718,7 +719,7 @@ class TestTensor:
             assert (tensor.mode_names == new_true_names)
 
         # check that you cannot use matrix of Tensor class and specify new name at the same time
-        with pytest.raises(ValueError):
+        with pytest.raises(ModeError):
             mode = 1
             tensor = Tensor(array=array_3d, mode_names=orig_names)
             matrix = Tensor(np.arange(new_dim[mode] * orig_dim[mode]).reshape(new_dim[mode], orig_dim[mode]))
@@ -726,7 +727,7 @@ class TestTensor:
             tensor.mode_n_product(matrix, mode=mode, new_name=new_name)
 
         # check that new_name should be of string type
-        with pytest.raises(TypeError):
+        with pytest.raises(ModeError):
             mode = 1
             tensor = Tensor(array=array_3d, mode_names=orig_names)
             matrix = np.arange(new_dim[mode] * orig_dim[mode]).reshape(new_dim[mode], orig_dim[mode])
@@ -834,18 +835,18 @@ class TestTensorCPD:
             TensorCPD(fmat=incorrect_fmat, core_values=correct_core_values)
 
         # all factor matrices should be a 2-dimensional numpy array
-        with pytest.raises(ValueError):
+        with pytest.raises(TensorTopologyError):
             incorrect_fmat = [fmat.copy() for fmat in correct_fmat]
             incorrect_fmat[0] = np.ones([2, 2, 2])
             TensorCPD(fmat=incorrect_fmat, core_values=correct_core_values)
 
         # too many (or not enough) `core_values` for `fmat`
-        with pytest.raises(ValueError):
+        with pytest.raises(TensorTopologyError):
             incorrect_core_values = np.ones(correct_core_values.size + 1)
             TensorCPD(fmat=correct_fmat, core_values=incorrect_core_values)
 
         # dimension all factor matrices should have the same number of columns
-        with pytest.raises(ValueError):
+        with pytest.raises(TensorTopologyError):
             incorrect_fmat = [fmat.copy() for fmat in correct_fmat]
             incorrect_fmat[0] = incorrect_fmat[0].T
             TensorCPD(fmat=incorrect_fmat, core_values=correct_core_values)
@@ -965,7 +966,7 @@ class TestTensorCPD:
             # wrong data type
             assert TensorCPD(fmat=fmat_1, core_values=core_values_1) + np.ones(R_2)
 
-        with pytest.raises(ValueError):
+        with pytest.raises(TensorTopologyError):
             # wrong topology which is determined by the ft_shape or number of dimensions
             ft_shape_new = ft_shape + (6,)
             fmat_2_new = [np.ones(i * R_2).reshape(i, R_2) for i in ft_shape_new]
@@ -973,7 +974,7 @@ class TestTensorCPD:
             t_cpd_2 = TensorCPD(fmat=fmat_2_new, core_values=core_values_2)
             assert t_cpd_1 + t_cpd_2
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ModeError):
             # wrong mode index
             t_cpd_1 = TensorCPD(fmat=fmat_1, core_values=core_values_1)
             t_cpd_2 = TensorCPD(fmat=fmat_2, core_values=core_values_2).set_mode_index(mode_index=new_mode_index)
@@ -1112,22 +1113,22 @@ class TestTensorCPD:
         assert all([tensor_cpd.modes[i].name == tensor_cpd_true.modes[i].name for i in range(tensor_cpd.order)])
 
         # ------ tests that should FAIL for new mode names being incorrectly defined for renaming
-        with pytest.raises(ValueError):
+        with pytest.raises(ModeError):
             # too many mode names
             incorrect_new_mode_names = {mode: "{}-mode".format(mode) for mode in range(true_order + 1)}
             tensor_cpd.set_mode_names(mode_names=incorrect_new_mode_names)
 
-        with pytest.raises(TypeError):
+        with pytest.raises(ModeError):
             # incorrect type of keys (not integers)
             incorrect_new_mode_names = {"{}-mode".format(mode): mode for mode in range(true_order)}
             tensor_cpd.set_mode_names(mode_names=incorrect_new_mode_names)
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ModeError):
             # key value exceeds the order of a tensor
             incorrect_new_mode_names = {mode: "{}-mode".format(mode) for mode in range(true_order - 2, true_order + 1)}
             tensor_cpd.set_mode_names(mode_names=incorrect_new_mode_names)
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ModeError):
             # key value is set to be negative
             incorrect_new_mode_names = {mode: "{}-mode".format(mode) for mode in range(-1, true_order - 1)}
             tensor_cpd.set_mode_names(mode_names=incorrect_new_mode_names)
@@ -1167,29 +1168,29 @@ class TestTensorCPD:
         assert all([tensor_cpd.modes[i].index == mode_index[i] for i in range(tensor_cpd.order)])
 
         # ------ tests that should FAIL for new mode index being incorrectly defined for renaming
-        with pytest.raises(ValueError):
+        with pytest.raises(ModeError):
             # too many lists of indices provided
             mode_index = {i: ["index"] for i in range(len(ft_shape) + 1)}
             tensor_cpd.set_mode_index(mode_index=mode_index)
 
-        with pytest.raises(TypeError):
+        with pytest.raises(ModeError):
             # incorrect type of keys (not integers)
             mode_index = {"index".format(mode): mode for mode in range(true_order)}
             tensor_cpd.set_mode_index(mode_index=mode_index)
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ModeError):
             # key value exceeds the order of a tensor
             wrong_key = true_order + 1
             mode_index = {wrong_key: ["idx"]}
             tensor_cpd.set_mode_index(mode_index=mode_index)
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ModeError):
             # key value exceeds the order of a tensor
             wrong_key = -1
             mode_index = {wrong_key: ["idx"]}
             tensor_cpd.set_mode_index(mode_index=mode_index)
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ModeError):
             # not enough indices for the length of the mode
             mode_index = {0: ["idx"]}
             tensor_cpd.set_mode_index(mode_index=mode_index)
@@ -1281,19 +1282,19 @@ class TestTensorTKD:
             TensorTKD(fmat=incorrect_fmat, core_values=correct_core_values)
 
         # all factor matrices should be a 2-dimensional numpy array
-        with pytest.raises(ValueError):
+        with pytest.raises(TensorTopologyError):
             incorrect_fmat = [fmat.copy() for fmat in correct_fmat]
             mode = 0
             incorrect_fmat[mode] = np.ones([ft_shape[mode], ml_rank[mode], 2])
             TensorTKD(fmat=incorrect_fmat, core_values=correct_core_values)
 
         # Not enough factor matrices for the specified core tensor
-        with pytest.raises(ValueError):
+        with pytest.raises(TensorTopologyError):
             incorrect_core_values = np.ones(correct_core_values.shape + (2,))
             TensorTKD(fmat=correct_fmat, core_values=incorrect_core_values)
 
         # number of columns of some factor matrices does not match the size of the corresponding mode of the core
-        with pytest.raises(ValueError):
+        with pytest.raises(TensorTopologyError):
             incorrect_fmat = [fmat.copy() for fmat in correct_fmat]
             incorrect_fmat[0] = incorrect_fmat[0].T
             TensorTKD(fmat=incorrect_fmat, core_values=correct_core_values)
@@ -1454,7 +1455,7 @@ class TestTensorTKD:
             # wrong data type
             assert TensorTKD(fmat=fmat_1, core_values=core_values_1) + np.ones(ml_rank_1)
 
-        with pytest.raises(ValueError):
+        with pytest.raises(TensorTopologyError):
             # wrong topology which is determined by the ft_shape or number of dimensions
             ft_shape_new = tuple(i + 1 for i in ft_shape)
             fmat_2_new = create_fmat(np.ones, ft_shape_new, ml_rank_2)
@@ -1462,7 +1463,7 @@ class TestTensorTKD:
             tensor_tkd_2 = TensorTKD(fmat=fmat_2_new, core_values=core_values_2)
             assert tensor_tkd_1 + tensor_tkd_2
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ModeError):
             # wrong mode index
             tensor_tkd_1 = TensorTKD(fmat=fmat_1, core_values=core_values_1)
             tensor_tkd_2 = TensorTKD(fmat=fmat_2, core_values=core_values_2).set_mode_index(mode_index=new_mode_index)
@@ -1759,24 +1760,24 @@ class TestTensorTT:
             TensorTT(core_values=incorrect_core_values)
 
         # not enough elements in core_values for the specified ft_shape
-        with pytest.raises(ValueError):
+        with pytest.raises(TensorTopologyError):
             incorrect_core_values = [correct_core_1, correct_core_2]
             TensorTT(core_values=incorrect_core_values)
 
         # first and last element of core_values should be 2-dimensional arrays
-        with pytest.raises(ValueError):
+        with pytest.raises(TensorTopologyError):
             shape = (2, 2, 2)
             incorrect_core_values = [np.ones(shape) for _ in range(len(correct_ft_shape))]
             TensorTT(core_values=incorrect_core_values)
 
         # All but first and last element of core_values should be 3-dimensional arrays
-        with pytest.raises(ValueError):
+        with pytest.raises(TensorTopologyError):
             shape = (2, 2)
             incorrect_core_values = [np.ones(shape) for _ in range(len(correct_ft_shape))]
             TensorTT(core_values=incorrect_core_values)
 
         # Last dimension of core_values[i] should be the same as the first dimension of core_values[i+1]
-        with pytest.raises(ValueError):
+        with pytest.raises(TensorTopologyError):
             incorrect_core_values = [np.ones((2, 3)), np.ones((3, 4, 5)), np.ones((6, 8))]
             TensorTT(core_values=incorrect_core_values)
 

--- a/hottbox/errors/__init__.py
+++ b/hottbox/errors/__init__.py
@@ -1,0 +1,51 @@
+"""
+This module includes all custom warnings and errors used across ``hottbox``.
+"""
+
+
+class TensorStateError(Exception):
+    """
+    Error raised when attempting to perform an operation on a ``Tensor``
+    which is not allowed for its current state
+    """
+    pass
+
+
+class TensorModeError(Exception):
+    """
+    Error raised when attempting to perform an operation on a ``Tensor``
+    which is not allowed by its ``Mode``
+    """
+    pass
+
+
+class TensorShapeError(Exception):
+    """
+    Error raised when attempting to perform an operation on a ``Tensor``
+    which is not allowed for its current shape
+    """
+    pass
+
+
+class TensorTopologyError(Exception):
+    """
+    Error related to the dimensionality mismatch of counterparts of
+    ``TensorCPD``, ``TensorTKD`` and ``TensorTT``
+    """
+    pass
+
+
+class StateError(Exception):
+    """
+    Error raised when there is an attempt to set
+    incorrect parameters for state of a ``Tensor``
+    """
+    pass
+
+
+class ModeError(Exception):
+    """
+    Error raised when there is an attempt to set
+    incorrect parameters for mode of a ``Tensor``
+    """
+    pass

--- a/hottbox/pdtools/tests/test_utils.py
+++ b/hottbox/pdtools/tests/test_utils.py
@@ -82,6 +82,6 @@ def test_tensor_to_pd():
     pd.testing.assert_frame_equal(df_mi, df_rec)
 
     # ----- tests that should FAILS
-    with pytest.raises(TypeError):
+    with pytest.raises(TensorStateError):
         tensor.unfold(0, inplace=True)
         tensor_to_pd(tensor=tensor)

--- a/hottbox/pdtools/utils.py
+++ b/hottbox/pdtools/utils.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pandas as pd
 from ..core.structures import Tensor
+from ..errors import TensorStateError
 
 
 def pd_to_tensor(df, keep_index=True):
@@ -98,6 +99,11 @@ def tensor_to_pd(tensor, col_name=None):
     -------
     df : pd.DataFrame
         Multi-index data frame
+
+    Raises
+    ------
+    TensorStateError
+        If ``tensor`` is not in normal state: ``tensor.in_normal_state is False``.
 
     Examples
     --------
@@ -207,7 +213,7 @@ def tensor_to_pd(tensor, col_name=None):
                    Wed           7
     """
     if not tensor.in_normal_state:
-        raise TypeError("`tensor` should be in normal state prior this conversion")
+        raise TensorStateError("`tensor` should be in normal state prior this conversion")
 
     # Create multidimensional index
     names = tensor.mode_names

--- a/hottbox/version.py
+++ b/hottbox/version.py
@@ -4,4 +4,4 @@ from __future__ import division
 from __future__ import absolute_import
 
 
-__version__ = '0.1.3'
+__version__ = '0.1.4'

--- a/hottbox/visualisation/__init__.py
+++ b/hottbox/visualisation/__init__.py
@@ -1,0 +1,286 @@
+"""
+This module is for EDA through interactive visualisation of the core structures:
+``TensorCPD``, ``TensorTKD`` etc.
+
+All its functionality should be used inside Jupyter Lab/ Jupyter Notebook.
+
+.. important::
+
+    The API provided by this module is experimental
+"""
+
+import numpy as np
+import ipywidgets as widgets
+import matplotlib.pyplot as plt  # This essentially can be replaced with `plotly` in a future
+from scipy import signal  # for generating testing data
+from hottbox.core import TensorCPD, TensorTKD  # for type hinting
+from IPython.display import display, clear_output
+
+
+def gen_test_data(plot=False):
+    """ Generate factor matrices which components will be easy to differentiate from one another
+
+    Parameters
+    ----------
+    plot : bool
+
+    Returns
+    -------
+    fmat : list[np.ndarray]
+    core_values : np.ndarray
+    """
+    t_A = np.linspace(0, 1, 500, endpoint=False).reshape(-1, 1)
+    t_B = np.linspace(0, 2, 10, endpoint=False).reshape(-1, 1)
+    t_C = np.linspace(-1, 1, 2 * 100, endpoint=False).reshape(-1, 1)
+    w_A = np.array([1, 2, 5]).reshape(-1, 1)
+    w_B = np.roll(w_A, 1)
+    w_C = np.array([0.3, 2, 0.7]).reshape(-1, 1)
+
+    A = np.sin         (2 * np.pi * t_A * w_A.T)
+    B = signal.square  (2 * np.pi * t_B * w_B.T)
+    C, _, _ = signal.gausspulse(t_C * w_C.T, fc=5, retquad=True, retenv=True)
+    fmat = [A, B, C]
+    core_values = np.array([1]*A.shape[1])
+
+    if plot:
+        for mode, factor in enumerate(fmat):
+            print("Mode-{} factor matrix shape = {}".format(mode, factor.shape))
+        fig, axis = plt.subplots(nrows=3,
+                                 ncols=1,
+                                 figsize=(8, 8)
+                                 )
+        axis[0].plot(t_A, A)
+        axis[0].set_title("Factor matrix A")
+        axis[1].plot(t_B, B)
+        axis[1].set_title("Factor matrix B")
+        axis[2].plot(t_C, C)
+        axis[2].set_title("Factor matrix C")
+        plt.tight_layout()
+    return fmat, core_values
+
+
+def gen_test_tensor_cpd():
+    """ Generate ``TensorCPD`` object for testing purposes
+
+    Returns
+    -------
+    TensorCPD
+    """
+    return TensorCPD(*gen_test_data())
+
+
+def _line_plot(ax, data):
+    """ Default plotting function for each mode
+
+    Parameters
+    ----------
+    ax : matplotlib.axes.Axes
+        Axes object which is used to illustrate `data`
+    data : np.ndarray
+        Array of data to be plotted. Shape of such array is ``(N, 1)``
+    """
+    ax.plot(data)
+
+
+def _bar_plot(ax, data):
+    """ Sample custom plot function """
+    ax.bar(x=range(data.shape[0]), height=data)
+
+BANK_OF_PLOTS = {
+    "line" : _line_plot,
+    "bar" : _bar_plot
+}
+
+
+def _main_plotting_function(tensor_cpd, group, plot_bank=None):
+
+    n_rows = 1
+    n_cols = tensor_cpd.order
+    axis_width = 4
+    axis_height = 4
+    fig, axis = plt.subplots(nrows=n_rows,
+                             ncols=n_cols,
+                             figsize=(n_cols * axis_width, n_rows * axis_height)
+                             )
+    if plot_bank is None:
+        plot_bank = {i: _line_plot for i in range(n_cols)}
+
+    for i, fmat in enumerate(tensor_cpd.fmat):
+        factor = group[i]
+        plot_function = plot_bank[i]
+        plot_function(ax=axis[i],
+                      data=fmat[:, factor])
+        axis[i].set_title("Factor matrix: {}".format(tensor_cpd.mode_names[i]))
+    plt.tight_layout()
+    return fig
+
+
+
+
+class PlotTensorCPD():
+    def __init__(self, tensor_cpd):
+        """
+
+        Parameters
+        ----------
+        tensor_cpd : TensorCPD
+        """
+        self.tensor_rep = tensor_cpd
+        self.sliders = self.create_fmat_sliders(tensor_cpd.fmat)
+        self.dropdown = self.create_dropdown(tensor_cpd.order)
+        self.out = widgets.Output()
+        self.dashboard = widgets.VBox([self.out,
+                                       widgets.HBox(self.sliders),
+                                       widgets.HBox(self.dropdown)
+                                       ])
+
+    @staticmethod
+    def create_fmat_sliders(fmat):
+        slider_list = [widgets.IntSlider(min=0, max=fmat[0].shape[1]-1)]
+        return slider_list
+
+    @staticmethod
+    def create_dropdown(number):
+        dropdown_list = [None] * number
+        for i in range(number):
+            dropdown_list[i] = widgets.Dropdown(options=['line', 'bar'],
+                                                value='line',
+                                                description='Plot type:',
+                                                disabled=False,
+                                                )
+        return dropdown_list
+
+    def general_callback(self, change):
+        plot_bank = {i: BANK_OF_PLOTS[dropdown.value] for i, dropdown in enumerate(self.dropdown)}
+        group = tuple([slider.value for slider in self.sliders])
+        with self.out:
+            fig = self.update_plot(group=group, plot_bank=plot_bank)
+            display(fig)
+            clear_output(wait=True)
+
+    def start_interacting(self):
+        for slider in self.sliders:
+            slider.observe(self.general_callback, names="value")
+
+        for dropdown in self.dropdown:
+            dropdown.observe(self.general_callback, names="value")
+
+        display(self.dashboard)
+
+    def update_plot(self, group, plot_bank=None):
+        new_group = group * self.tensor_rep.order
+        fig = _main_plotting_function(tensor_cpd=self.tensor_rep, group=new_group, plot_bank=plot_bank)
+        return fig
+
+
+
+
+
+
+class PlotTensorTKD():
+    def __init__(self, tensor_tkd):
+        """
+
+        Parameters
+        ----------
+        tensor_tkd : TensorTKD
+        """
+        self.tensor_rep = tensor_tkd
+        self.out = widgets.Output()
+        self.sliders = self.create_fmat_sliders(tensor_tkd.fmat)
+        self.dropdown = self.create_dropdown(tensor_tkd.order)
+        self.dashboard = widgets.VBox([self.out,
+                                       widgets.HBox(self.sliders),
+                                       widgets.HBox(self.dropdown)
+                                       ])
+
+    @staticmethod
+    def create_fmat_sliders(fmat):
+        slider_list = [None] * len(fmat)
+        for i, f in enumerate(fmat):
+            slider_list[i] = widgets.IntSlider(min=0, max=f.shape[1]-1)
+        return slider_list
+
+    @staticmethod
+    def create_dropdown(number):
+        dropdown_list = [None] * number
+        for i in range(number):
+            dropdown_list[i] = widgets.Dropdown(options=['line', 'bar'],
+                                                value='line',
+                                                description='Plot type:',
+                                                disabled=False,
+                                                )
+        return dropdown_list
+
+    def general_callback(self, change):
+        plot_bank = {i: BANK_OF_PLOTS[dropdown.value] for i, dropdown in enumerate(self.dropdown)}
+        group = tuple([slider.value for slider in self.sliders])
+        with self.out:
+            fig = self.update_plot(group=group, plot_bank=plot_bank)
+            display(fig)
+            clear_output(wait=True)
+
+    def start_interacting(self):
+        for slider in self.sliders:
+            slider.observe(self.general_callback, names="value")
+
+        for dropdown in self.dropdown:
+            dropdown.observe(self.general_callback, names="value")
+
+        display(self.dashboard)
+
+
+    def update_plot(self, group, plot_bank):
+        fig = _main_plotting_function(tensor_cpd=self.tensor_rep, group=group, plot_bank=plot_bank)
+        return fig
+
+
+
+
+
+
+
+
+
+
+
+
+class BaseIplot():
+    def __init__(self, tensor_rep):
+        """
+
+        Parameters
+        ----------
+        tensor_rep : {TensorCPD, TensorTKD}
+        """
+        self.tensor_rep = tensor_rep
+        self.out = widgets.Output()
+        self.sliders = self.create_fmat_sliders()
+        self.dropdown = self.create_plot_type_dropdown()
+        self.dashboard = self.assemble_dashboard()
+
+    # def create_fmat_sliders(self, params):
+    #     sliders_list = [None] * len(params)
+    #     for i in
+    #     pass
+
+    def create_plot_type_dropdown(self):
+        pass
+
+    def start_interacting(self):
+        pass
+
+    def assemble_dashboard(self):
+        pass
+
+    def slider_callback(self, change):
+        pass
+
+    def dropdown_callback(self, change):
+        pass
+
+    def update_plot(self):
+        with self.out:
+            fig = _main_plotting_function()
+
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
 numpy==1.14.2
 scipy==1.0.1
 pandas==0.22.0
+matplotlib
+ipython
+ipywidgets


### PR DESCRIPTION
Experimental module for interactive visualisation of factor matrices of `TensorCPD` and `TensorTKD` in jupyter notbook or jupyte lab.
These changes require to have additional dependencies of the following packages:
1. `matplotlib`
2. `ipython`
3. `ipywidgets`
All of them are pretty stable and very common for EDA.

The following examples assume that each factor matrix of both `TensorCPD` and `TensorTKD` has only three components which look like following:
![fmat_data](https://user-images.githubusercontent.com/16823400/44157071-705f2180-a0a9-11e8-8c14-c45ada729633.png)


## General principle
1. Use  sliders to select which components to plot
2. Use dropdown to select how to plot selected components
3. When any selection is changed, the callback function is triggered which updates the axes.

**Note:** In case of `TensorCPD` visualisation, there is only one slider for selecting which factor vectors to plot. This is due to the nature of the kruskal representation, i.e. one to one relation between the factor vectors from factor matrices of different modes.


### Visualisation fo `TensorCPD`
```python
from hottbox.visualisation import ComponentPlotCPD
p = ComponentPlotCPD(tensor_cpd)
```
![cpd_plot](https://user-images.githubusercontent.com/16823400/44154562-e60dde82-a0a2-11e8-88ba-d5b65c7dd00d.png)


### Visualisation fo `TensorTKD`
```python
from hottbox.visualisation import ComponentPlotTKD
p = ComponentPlotTKD(tensor_tkd)
```
![tucker_plot](https://user-images.githubusercontent.com/16823400/44154582-f1d10fe6-a0a2-11e8-8ffd-e17307e395c7.png)


## Extending plotting
By default only two plotting functions are provided: line plot and bar plot. However, it is easy to change or extend this. Custom function which accepts two arguments `ax` and `data` can be passed to the `extend_available_plots()`.


### Simple function for all modes
```python
def my_line_plot(ax, data):
    """
    ax : Axes object which is used to illustrate `data`  
    data : selected factor vector to be plotted
    """    
    ax.plot(data, 'r+')
    
custom_plots = {"my line": my_line_plot}  # key will be displayed in the dropdown menu
p.extend_available_plots(custom_plots)  # will be available for all modes
p.dashboard
```
![custom_plot_all_modes](https://user-images.githubusercontent.com/16823400/44158518-c386a380-a0ac-11e8-9c02-8b1037545aa8.png)


### Complex function for some modes
Custom function is not restricted to the use of `matplotlib`. It also doesn't have to use all values from the factor vector.

```python
import mne  # `hottbox` does not depend on this package

def my_topo_plot(ax, data):
    """
    ax : Axes object which is used to illustrate `data`  
    data : selected factor vector to be plotted
    """
    ch_names = ['Cz', 'Oz', 'T7', 'FT9', 'T8', 'FT10', 'M1', 'M2']
    info = mne.create_info(ch_names=ch_names, sfreq=1200, ch_types='eeg', verbose=False)
    montage = mne.channels.read_montage("standard_1020")
    temp = data.reshape(-1, 1)
    temp = temp [:8,:]
    
    
    raw = mne.io.RawArray(temp, info, verbose=False)
    raw.set_montage(montage)
    raw.set_eeg_reference("average", projection=False)
    temp = data[:8]
        
    im = mne.viz.plot_topomap(temp,
                              raw.info,
                              names=ch_names,
                              axes = ax,
                              show_names = False,
                              cmap = 'RdBu_r',
                              sensors = 'k.',
                              outlines = 'head',
                              show=False
                        )
    
custom_plots = {"my topo": my_topo_plot}  # key will be displayed in the dropdown menu
p.extend_available_plots(custom_plots, modes=[1]) # will be available only for the mode-1
p.dashboard
```
![custom_plot_some_modes](https://user-images.githubusercontent.com/16823400/44158524-c8e3ee00-a0ac-11e8-965b-571b01b09513.png)